### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4,7 +4,17 @@ const cors = require("cors");
 const { OpenAI } = require("openai");
 
 admin.initializeApp();
-const openai = new OpenAI({ apiKey: functions.config().openai.key });
+const openaiApiKey =
+  (functions.config().openai && functions.config().openai.key) ||
+  process.env.OPENAI_API_KEY;
+
+if (!openaiApiKey) {
+  console.error(
+    "Missing OpenAI API key. Set via 'firebase functions:config:set openai.key=YOUR_API_KEY' or 'process.env.OPENAI_API_KEY'."
+  );
+}
+
+const openai = new OpenAI({ apiKey: openaiApiKey || "" });
 
 const corsHandler = cors({ origin: true });
 
@@ -18,11 +28,17 @@ exports.callGpt = functions.https.onRequest((req, res) => {
       return res.status(405).send("Method Not Allowed");
     }
 
-    const { message } = req.body;
+  const { message } = req.body;
 
-    if (!message || typeof message !== "string") {
-      return res.status(400).send("Invalid message");
-    }
+  if (!message || typeof message !== "string") {
+    return res.status(400).send("Invalid message");
+  }
+
+  if (!openaiApiKey) {
+    return res.status(500).json({
+      reply: "⚠️ OpenAI API key is not configured.",
+    });
+  }
 
     try {
       const chatCompletion = await openai.chat.completions.create({

--- a/public/script.js
+++ b/public/script.js
@@ -64,18 +64,32 @@ async function sendMessage() {
     timestamp: Date.now()
   });
 
-  const response = await fetch("https://us-central1-shared-gpt-brainstorm.cloudfunctions.net/callGpt", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ message: input, room: currentRoom })
-  });
+  try {
+    const response = await fetch("https://us-central1-shared-gpt-brainstorm.cloudfunctions.net/callGpt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: input, room: currentRoom })
+    });
 
-  const data = await response.json();
-  await db.collection("rooms").doc(currentRoom).collection("messages").add({
-    text: data.reply,
-    sender: "GPT",
-    timestamp: Date.now()
-  });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Server Error: ${errorText}`);
+    }
+
+    const data = await response.json();
+    await db.collection("rooms").doc(currentRoom).collection("messages").add({
+      text: data.reply,
+      sender: "GPT",
+      timestamp: Date.now()
+    });
+  } catch (error) {
+    console.error("Error fetching GPT response:", error);
+    await db.collection("rooms").doc(currentRoom).collection("messages").add({
+      text: "⚠️ GPT connection failed.",
+      sender: "System",
+      timestamp: Date.now()
+    });
+  }
 }
 
 async function clearRoom() {


### PR DESCRIPTION
## Summary
- check for missing OpenAI key in Firebase Function
- add fallback to read key from environment variable
- improve client-side error handling for GPT requests

## Testing
- `npm test --silent` *(fails: command has no tests and network calls blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685a4281737c8330bd843b559323ed3e