### PR TITLE
Display username in chat and rename bot

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
 </head>
 <body>
   <h2>Select a Room</h2>
+  <input id="usernameInput" placeholder="Your name" onchange="setUsername()" />
   <select id="roomSelector" onchange="changeRoom()">
     <option value="general">General</option>
     <option value="marketing">Marketing</option>
@@ -167,11 +168,20 @@
     const db = firebase.firestore();
 
     let currentRoom = "general";
+    let username = localStorage.getItem('username') || 'User';
     let unsubscribe = null;
 
     function changeRoom() {
       currentRoom = document.getElementById("roomSelector").value;
       loadMessages();
+    }
+
+    function setUsername() {
+      const input = document.getElementById('usernameInput').value.trim();
+      if (input) {
+        username = input;
+        localStorage.setItem('username', username);
+      }
     }
 
     function formatTimestamp(timestamp) {
@@ -194,7 +204,7 @@
           chatBox.innerHTML = "<h3>History for: " + currentRoom + "</h3>";
           snapshot.forEach(doc => {
             const msg = doc.data();
-            const msgClass = msg.sender === "user" ? "user" : "gpt";
+          const msgClass = msg.sender === username ? "user" : "gpt";
             const msgDate = formatDate(msg.timestamp);
             if (msgDate !== lastDate) {
               chatBox.innerHTML += `<div class='date-divider'>${msgDate}</div>`;
@@ -217,7 +227,7 @@
 
       await db.collection("rooms").doc(currentRoom).collection("messages").add({
         text: input,
-        sender: "user",
+        sender: username,
         timestamp: Date.now()
       });
 
@@ -230,7 +240,7 @@
       const data = await response.json();
       await db.collection("rooms").doc(currentRoom).collection("messages").add({
         text: data.reply,
-        sender: "GPT",
+        sender: "Storm",
         timestamp: Date.now()
       });
     }
@@ -263,6 +273,7 @@
     window.onload = () => {
       const savedTheme = localStorage.getItem('theme') || 'dark';
       document.body.classList.add(savedTheme);
+      document.getElementById('usernameInput').value = username;
       loadMessages();
     }
   </script>

--- a/main.js
+++ b/main.js
@@ -11,12 +11,21 @@ firebase.initializeApp(firebaseConfig);
 const db = firebase.firestore();
 
 let currentRoom = "general";
+let username = localStorage.getItem('username') || 'User';
 let unsubscribe = null;
 
 function changeRoom() {
   const newRoom = document.getElementById("roomSelector").value;
   currentRoom = newRoom;
   loadMessages();
+}
+
+function setUsername() {
+  const input = document.getElementById('usernameInput').value.trim();
+  if (input) {
+    username = input;
+    localStorage.setItem('username', username);
+  }
 }
 
 function loadMessages() {
@@ -43,7 +52,7 @@ async function sendMessage() {
 
   await db.collection("rooms").doc(currentRoom).collection("messages").add({
     text: input,
-    sender: "user",
+    sender: username,
     timestamp: Date.now()
   });
 
@@ -70,7 +79,7 @@ async function sendMessage() {
     const reply = data.reply;
     await db.collection("rooms").doc(currentRoom).collection("messages").add({
       text: reply,
-      sender: "GPT",
+      sender: "Storm",
       timestamp: Date.now()
     });
   } catch (error) {
@@ -83,4 +92,7 @@ async function sendMessage() {
   }
 }
 
-window.onload = loadMessages;
+window.onload = () => {
+  document.getElementById('usernameInput').value = username;
+  loadMessages();
+};

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,8 @@
         <option value="tech">Tech</option>
         <option value="design">Design</option>
       </select>
+      <label for="usernameInput">Username</label>
+      <input id="usernameInput" placeholder="Your name" onchange="setUsername()" />
     </div>
   </aside>
 

--- a/public/script.js
+++ b/public/script.js
@@ -10,11 +10,20 @@ firebase.initializeApp(firebaseConfig);
 const db = firebase.firestore();
 
 let currentRoom = "general";
+let username = localStorage.getItem("username") || "User";
 let unsubscribe = null;
 
 function changeRoom() {
   currentRoom = document.getElementById("roomSelector").value;
   loadMessages();
+}
+
+function setUsername() {
+  const input = document.getElementById("usernameInput").value.trim();
+  if (input) {
+    username = input;
+    localStorage.setItem("username", username);
+  }
 }
 
 function formatTimestamp(timestamp) {
@@ -36,7 +45,7 @@ function loadMessages() {
       chatBox.innerHTML = "<h3>History for: " + currentRoom + "</h3>";
       snapshot.forEach(doc => {
         const msg = doc.data();
-        const msgClass = msg.sender === "user" ? "user" : "gpt";
+      const msgClass = msg.sender === username ? "user" : "gpt";
         const msgDate = formatDate(msg.timestamp);
         if (msgDate !== lastDate) {
           chatBox.innerHTML += `<div class='date-divider'>${msgDate}</div>`;
@@ -59,7 +68,7 @@ async function sendMessage() {
 
   await db.collection("rooms").doc(currentRoom).collection("messages").add({
     text: input,
-    sender: "user",
+    sender: username,
     timestamp: Date.now()
   });
 
@@ -88,7 +97,7 @@ async function sendMessage() {
 
     await db.collection("rooms").doc(currentRoom).collection("messages").add({
       text: data.reply,
-      sender: "GPT",
+      sender: "Storm",
       timestamp: Date.now()
     });
   } catch (error) {
@@ -129,6 +138,7 @@ function focusInput() {
 window.onload = () => {
   const savedTheme = localStorage.getItem('theme') || 'dark';
   document.body.classList.add(savedTheme);
+  document.getElementById('usernameInput').value = username;
   loadMessages();
   document.getElementById('userInput').addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/public/style.css
+++ b/public/style.css
@@ -35,6 +35,7 @@ body {
 
 .message.bot {
   align-self: flex-start;
+}
 
 
 /* ======= შეტყობინების შესატანი ======= */


### PR DESCRIPTION
## Summary
- add a username input in the sidebar
- store username locally and use it when sending messages
- rename GPT bot to **Storm**
- close missing CSS bracket

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_6862503be4408330a87a2ef68209f87e