### PR TITLE
Enable multi-user chat in public demo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Shared GPT Brainstorm</title>
   <link rel="stylesheet" href="style.css" />
+  <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
 </head>
 <body>
   <main class="chat-container">
@@ -12,6 +14,8 @@
       <span class="logo">🌀</span>
       <h1>Shared GPT Brainstorm</h1>
     </header>
+
+    <input id="usernameInput" placeholder="Your name" onchange="setUsername()" />
 
     <section id="chatBox" class="chat-box">
       <!-- Messages appear here -->


### PR DESCRIPTION
## Summary
- add Firebase scripts and username input to public index
- persist messages to Firestore and load them for all users
- handle GPT responses and errors via Firestore

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_6863e2dfa0bc8330b742fc1a9bb50bd3