### PR TITLE
Fix send button event handling

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -149,3 +149,18 @@ function hideTyping() {
     typingWrapper.remove();
   }
 }
+
+// ✅ Event listeners for sending messages
+const sendBtn = document.getElementById("sendButton");
+const inputEl = document.getElementById("userInput");
+if (sendBtn) {
+  sendBtn.addEventListener("click", sendMessage);
+}
+if (inputEl) {
+  inputEl.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- make the send button functional by binding click and Enter key events in `public/script.js`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6864f88dec8483309d8745714de25d79