### PR TITLE
Fix missing Cloud Functions deployment config

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "functions": {
+    "source": "functions"
+  },
   "hosting": {
     "public": "public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]


### PR DESCRIPTION
## Summary
- add `functions` configuration in `firebase.json` so `firebase deploy --only functions` works

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `cd functions && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6865070e18e483309c4c1424e8b9e7ea