### PR TITLE
Enable shared chat writes

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    ".read": true,
+    ".write": true
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -5,5 +5,8 @@
   "hosting": {
     "public": "public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+  },
+  "database": {
+    "rules": "database.rules.json"
   }
 }


### PR DESCRIPTION
## Summary
- allow realtime DB writes by adding database rules
- configure Firebase to use the database rules file

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686528167aa88330b82080dbf03fe8b0